### PR TITLE
auto capitalized matno for students

### DIFF
--- a/forms/js/extra-scripts.js
+++ b/forms/js/extra-scripts.js
@@ -10,7 +10,9 @@
 
 
         var form = $( this );
-        var MatNo = $("#matno").val();
+        var MatNox = $("#matno").val();
+        var MatNo = MatNox.toUpperCase();
+        
 
         $.ajax({
             type: "POST",


### PR DESCRIPTION
Discovered that MatNo calls unprocessed input of users, which automatically degrades the users experience, did notice some other errors too, but I am going make other slight pull request if this request is merged